### PR TITLE
Discord認証を実装

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["lh3.googleusercontent.com"],
+    domains: ["lh3.googleusercontent.com", "cdn.discordapp.com"],
   },
 };
 

--- a/src/app/api/auth/[...nextauth]/options.ts
+++ b/src/app/api/auth/[...nextauth]/options.ts
@@ -1,6 +1,7 @@
 import { NextAuthOptions } from "next-auth";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import GoogleProvider from "next-auth/providers/google";
+import DiscordProvider from "next-auth/providers/discord";
 import prisma from "@/src/lib/prisma";
 
 const authOptions: NextAuthOptions = {
@@ -10,7 +11,10 @@ const authOptions: NextAuthOptions = {
       clientId: process.env.GOOGLE_CLIENT_ID as string,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
     }),
-    // TODO: discord認証もやりたい
+    DiscordProvider({
+      clientId: process.env.AUTH_DISCORD_ID as string,
+      clientSecret: process.env.AUTH_DISCORD_SECRET as string,
+    }),
   ],
   session: {
     strategy: "jwt",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Image from "next/image";
-import GoogleLoginForm from "../components/auth/GoogleLoginForm";
+import LoginForm from "../components/auth/LoginForm";
 import LogoutButton from "../components/auth/LogoutButton";
 import DisplayContent from "../components/reflection/view";
 import { useSession } from "next-auth/react";
@@ -29,7 +29,7 @@ const Home = () => {
       </>
     ) : (
       <>
-        <GoogleLoginForm />
+        <LoginForm />
       </>
     );
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,9 @@ const Home = () => {
         <DisplayContent />
       </>
     ) : (
-      <GoogleLoginForm />
+      <>
+        <GoogleLoginForm />
+      </>
     );
   }
 };

--- a/src/components/auth/DiscordLoginButton.tsx
+++ b/src/components/auth/DiscordLoginButton.tsx
@@ -1,5 +1,4 @@
 import { Box } from "@mui/material";
-import React from "react";
 import { AuthButton } from "../shared/button";
 import { FaDiscord } from "react-icons/fa";
 import { signIn } from "next-auth/react";

--- a/src/components/auth/DiscordLoginButton.tsx
+++ b/src/components/auth/DiscordLoginButton.tsx
@@ -6,7 +6,7 @@ import { signIn } from "next-auth/react";
 
 const DiscordLoginButton = () => {
   return (
-    <Box px={{ xs: 2, md: 5 }}>
+    <Box px={{ xs: 2, md: 5 }} mt={2}>
       <AuthButton
         label="Discordでログイン"
         icon={FaDiscord}

--- a/src/components/auth/DiscordLoginButton.tsx
+++ b/src/components/auth/DiscordLoginButton.tsx
@@ -1,0 +1,28 @@
+import { Box } from "@mui/material";
+import React from "react";
+import { AuthButton } from "../shared/button";
+import { FaDiscord } from "react-icons/fa";
+import { signIn } from "next-auth/react";
+
+const DiscordLoginButton = () => {
+  return (
+    <Box px={{ xs: 2, md: 5 }}>
+      <AuthButton
+        label="Discordでログイン"
+        icon={FaDiscord}
+        onClick={() =>
+          signIn("discord", {
+            callbackUrl: "/",
+          })
+        }
+        sx={{
+          width: "100%",
+          color: "black",
+          border: "1px solid #c4c4c4",
+        }}
+      />
+    </Box>
+  );
+};
+
+export default DiscordLoginButton;

--- a/src/components/auth/GoogleLoginButton.tsx
+++ b/src/components/auth/GoogleLoginButton.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { Box } from "@mui/material";
 import { FcGoogle } from "react-icons/fc";
 import { signIn } from "next-auth/react";

--- a/src/components/auth/GoogleLoginButton.tsx
+++ b/src/components/auth/GoogleLoginButton.tsx
@@ -6,7 +6,7 @@ import { AuthButton } from "../shared/button";
 
 const GoogleLoginButton = () => {
   return (
-    <Box px={{ xs: 2, md: 5 }}>
+    <Box px={{ xs: 2, md: 5 }} mt={2}>
       <AuthButton
         label="Googleでログイン"
         icon={FcGoogle}

--- a/src/components/auth/GoogleLoginForm.tsx
+++ b/src/components/auth/GoogleLoginForm.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import GoogleLoginButton from "./GoogleLoginButton";
+import DiscordLoginButton from "./DiscordLoginButton";
 
 const GoogleLoginForm = () => {
   return (
@@ -18,6 +19,7 @@ const GoogleLoginForm = () => {
         ログインすると〇〇の機能が使えるようになります
       </Typography>
       <GoogleLoginButton />
+      <DiscordLoginButton />
     </Box>
   );
 };

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from "@mui/material";
 import GoogleLoginButton from "./GoogleLoginButton";
 import DiscordLoginButton from "./DiscordLoginButton";
 
-const GoogleLoginForm = () => {
+const LoginForm = () => {
   return (
     <Box
       mt={15}
@@ -24,4 +24,4 @@ const GoogleLoginForm = () => {
   );
 };
 
-export default GoogleLoginForm;
+export default LoginForm;

--- a/src/components/pages/ReflectionPostPage.tsx
+++ b/src/components/pages/ReflectionPostPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
-import GoogleLoginForm from "../auth/GoogleLoginForm";
+import LoginForm from "../auth/LoginForm";
 import { useRouter } from "next/navigation";
 import { User } from "next-auth";
 import { z } from "zod";
@@ -65,7 +65,7 @@ const ReflectionPostPage: React.FC<ReflectionPostPageProps> = ({
       errors={errors}
     />
   ) : (
-    <GoogleLoginForm />
+    <LoginForm />
   );
 };
 


### PR DESCRIPTION
## 編集
- Discord認証を実装

## スクリーンショット
<img width="1470" alt="スクリーンショット 2024-10-19 18 22 34" src="https://github.com/user-attachments/assets/0953ab78-b3e8-4141-8752-fc4480f6d783">
<img width="412" alt="スクリーンショット 2024-10-19 18 22 57" src="https://github.com/user-attachments/assets/71593193-013d-487e-8bdd-b6eddc446fa0">

## 備考
- GitHub認証のボタンをつけたらボタンのところを共通コンポーネントにしたい。
- NextAuthの仕様でGoogleとDiscordのログインが同じメールアドレスの場合、複数のサインイン方法がブロックされてしまうみたいなのでテストの時は一旦データベースの情報を消す必要があります。
https://next-auth.js.org/faq
https://stackoverflow.com/questions/76851751/next-auth-with-google-provider-to-confirm-your-identity-sign-in-with-the-same